### PR TITLE
Enable full labels for container cpu usage

### DIFF
--- a/diagnostic-script.sh
+++ b/diagnostic-script.sh
@@ -1,0 +1,230 @@
+#!/bin/bash
+
+echo "=== EKS Container Metrics Diagnostic Script ==="
+echo "This script will help diagnose issues with container_cpu_usage_seconds_total labels"
+echo ""
+
+# Function to check if kubectl is available
+check_kubectl() {
+    if ! command -v kubectl &> /dev/null; then
+        echo "❌ kubectl is not installed or not in PATH"
+        exit 1
+    fi
+    echo "✅ kubectl is available"
+}
+
+# Function to check cluster connectivity
+check_cluster_connectivity() {
+    echo ""
+    echo "🔍 Checking cluster connectivity..."
+    if kubectl cluster-info &> /dev/null; then
+        echo "✅ Connected to cluster: $(kubectl config current-context)"
+    else
+        echo "❌ Cannot connect to cluster"
+        exit 1
+    fi
+}
+
+# Function to check if monitoring namespace exists
+check_monitoring_namespace() {
+    echo ""
+    echo "🔍 Checking monitoring namespace..."
+    if kubectl get namespace monitoring &> /dev/null; then
+        echo "✅ Monitoring namespace exists"
+    else
+        echo "❌ Monitoring namespace does not exist"
+        echo "Create it with: kubectl create namespace monitoring"
+        exit 1
+    fi
+}
+
+# Function to check kubelet service
+check_kubelet_service() {
+    echo ""
+    echo "🔍 Checking kubelet service in kube-system..."
+    if kubectl get service -n kube-system -l k8s-app=kubelet &> /dev/null; then
+        echo "✅ Kubelet service found"
+        kubectl get service -n kube-system -l k8s-app=kubelet
+    else
+        echo "⚠️  Kubelet service not found with label k8s-app=kubelet"
+        echo "Available services in kube-system:"
+        kubectl get services -n kube-system
+    fi
+}
+
+# Function to check direct cAdvisor metrics from a node
+check_cadvisor_direct() {
+    echo ""
+    echo "🔍 Checking cAdvisor metrics directly from kubelet..."
+    
+    # Get a node name
+    NODE_NAME=$(kubectl get nodes -o jsonpath='{.items[0].metadata.name}')
+    if [ -z "$NODE_NAME" ]; then
+        echo "❌ No nodes found in cluster"
+        return 1
+    fi
+    
+    echo "Testing on node: $NODE_NAME"
+    
+    # Try to get cAdvisor metrics
+    echo "Fetching container_cpu_usage_seconds_total metrics..."
+    METRICS=$(kubectl get --raw "/api/v1/nodes/$NODE_NAME/proxy/metrics/cadvisor" 2>/dev/null | grep "container_cpu_usage_seconds_total" | head -5)
+    
+    if [ -n "$METRICS" ]; then
+        echo "✅ cAdvisor metrics are available. Sample metrics:"
+        echo "$METRICS"
+        
+        # Check if labels are present
+        if echo "$METRICS" | grep -q 'pod="[^"]*"' && echo "$METRICS" | grep -q 'namespace="[^"]*"'; then
+            echo "✅ Pod and namespace labels are present in the raw metrics"
+        else
+            echo "⚠️  Pod or namespace labels might be missing in raw metrics"
+        fi
+    else
+        echo "❌ No container_cpu_usage_seconds_total metrics found"
+        echo "This might indicate a cAdvisor configuration issue"
+    fi
+}
+
+# Function to check Prometheus Agent status
+check_prometheus_agent() {
+    echo ""
+    echo "🔍 Checking Prometheus Agent status..."
+    
+    if kubectl get prometheusagent -n monitoring cluster-agent &> /dev/null; then
+        echo "✅ Prometheus Agent 'cluster-agent' found"
+        
+        # Check if it's ready
+        STATUS=$(kubectl get prometheusagent -n monitoring cluster-agent -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null)
+        if [ "$STATUS" = "True" ]; then
+            echo "✅ Prometheus Agent is ready"
+        else
+            echo "⚠️  Prometheus Agent might not be ready"
+            echo "Status:"
+            kubectl get prometheusagent -n monitoring cluster-agent -o yaml | grep -A 10 "status:"
+        fi
+    else
+        echo "❌ Prometheus Agent 'cluster-agent' not found"
+    fi
+}
+
+# Function to check ServiceMonitors
+check_service_monitors() {
+    echo ""
+    echo "🔍 Checking ServiceMonitors..."
+    
+    SM_COUNT=$(kubectl get servicemonitor -n monitoring --selector=release=prometheus-agent --no-headers 2>/dev/null | wc -l)
+    if [ "$SM_COUNT" -gt 0 ]; then
+        echo "✅ Found $SM_COUNT ServiceMonitors with release=prometheus-agent"
+        kubectl get servicemonitor -n monitoring --selector=release=prometheus-agent
+        
+        # Check kubelet-metrics specifically
+        if kubectl get servicemonitor -n monitoring kubelet-metrics &> /dev/null; then
+            echo "✅ kubelet-metrics ServiceMonitor found"
+        else
+            echo "⚠️  kubelet-metrics ServiceMonitor not found"
+        fi
+    else
+        echo "❌ No ServiceMonitors found with release=prometheus-agent"
+    fi
+}
+
+# Function to check pod resource definitions
+check_pod_resources() {
+    echo ""
+    echo "🔍 Checking if pods have resource requests/limits defined..."
+    
+    # Get a sample of pods and check their resource definitions
+    PODS_WITHOUT_RESOURCES=$(kubectl get pods --all-namespaces -o json | jq -r '.items[] | select(.spec.containers[].resources.requests.cpu == null or .spec.containers[].resources.requests.memory == null) | "\(.metadata.namespace)/\(.metadata.name)"' 2>/dev/null | head -5)
+    
+    if [ -n "$PODS_WITHOUT_RESOURCES" ]; then
+        echo "⚠️  Found pods without resource requests (this can affect metric labels):"
+        echo "$PODS_WITHOUT_RESOURCES"
+        echo ""
+        echo "Consider adding resource requests to your pod specifications:"
+        echo "resources:"
+        echo "  requests:"
+        echo "    cpu: 100m"
+        echo "    memory: 100Mi"
+    else
+        echo "✅ Most pods have resource requests defined"
+    fi
+}
+
+# Function to test metric query
+test_metric_query() {
+    echo ""
+    echo "🔍 Testing metric availability..."
+    
+    # Check if we can port-forward to prometheus agent
+    echo "Attempting to check Prometheus Agent metrics endpoint..."
+    
+    # Get prometheus agent pod
+    PROM_POD=$(kubectl get pods -n monitoring -l app.kubernetes.io/name=prometheus-agent -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+    
+    if [ -n "$PROM_POD" ]; then
+        echo "Found Prometheus Agent pod: $PROM_POD"
+        
+        # Test if we can access the metrics endpoint
+        echo "Testing metrics endpoint access..."
+        timeout 10s kubectl port-forward -n monitoring pod/$PROM_POD 9090:9090 &
+        PF_PID=$!
+        sleep 3
+        
+        # Try to query metrics
+        if curl -s http://localhost:9090/metrics | grep -q "prometheus_agent"; then
+            echo "✅ Prometheus Agent metrics endpoint is accessible"
+        else
+            echo "⚠️  Cannot access Prometheus Agent metrics endpoint"
+        fi
+        
+        # Clean up port-forward
+        kill $PF_PID 2>/dev/null
+    else
+        echo "❌ Prometheus Agent pod not found"
+    fi
+}
+
+# Function to provide recommendations
+provide_recommendations() {
+    echo ""
+    echo "📋 RECOMMENDATIONS:"
+    echo ""
+    echo "1. Apply the fixed configuration:"
+    echo "   kubectl apply -f prometheus-config-fixed.yaml"
+    echo ""
+    echo "2. Ensure all your application pods have resource requests/limits:"
+    echo "   resources:"
+    echo "     requests:"
+    echo "       cpu: 100m"
+    echo "       memory: 100Mi"
+    echo "     limits:"
+    echo "       cpu: 500m"
+    echo "       memory: 500Mi"
+    echo ""
+    echo "3. Wait 2-3 minutes after applying changes, then verify metrics:"
+    echo "   kubectl get --raw \"/api/v1/nodes/\$(kubectl get nodes -o jsonpath='{.items[0].metadata.name}')/proxy/metrics/cadvisor\" | grep container_cpu_usage_seconds_total | head -3"
+    echo ""
+    echo "4. Check Prometheus Agent logs if issues persist:"
+    echo "   kubectl logs -n monitoring -l app.kubernetes.io/name=prometheus-agent"
+    echo ""
+    echo "5. Verify your EKS cluster version supports the required metrics:"
+    echo "   kubectl version --short"
+}
+
+# Main execution
+main() {
+    check_kubectl
+    check_cluster_connectivity
+    check_monitoring_namespace
+    check_kubelet_service
+    check_cadvisor_direct
+    check_prometheus_agent
+    check_service_monitors
+    check_pod_resources
+    test_metric_query
+    provide_recommendations
+}
+
+# Run the diagnostic
+main

--- a/prometheus-config-fixed.yaml
+++ b/prometheus-config-fixed.yaml
@@ -1,0 +1,337 @@
+# Prometheus Agent
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: PrometheusAgent
+metadata:
+  name: cluster-agent
+  namespace: monitoring
+spec:
+  serviceAccountName: prometheus-agent
+  serviceMonitorSelector:
+    matchLabels:
+      release: prometheus-agent
+  podMonitorSelector:
+    matchLabels:
+      release: prometheus-agent
+  serviceMonitorNamespaceSelector: {}
+  podMonitorNamespaceSelector: {}
+  probeSelector:
+    matchLabels:
+      release: prometheus-agent
+  scrapeInterval: 15s
+  remoteWrite:
+  - url: "http://10.0.3.115:9090/api/v1/write"
+    writeRelabelConfigs:
+      # Add cluster label
+      - targetLabel: cluster
+        replacement: "stress-tests-eks"
+
+      # Handle exported_* labels from kube-state-metrics
+      - sourceLabels: [exported_namespace]
+        targetLabel: namespace
+        action: replace
+      - sourceLabels: [exported_pod]
+        targetLabel: pod
+        action: replace  
+      - sourceLabels: [exported_container]
+        targetLabel: container
+        action: replace
+      - regex: "exported_.*"
+        action: labeldrop
+
+      # Normalize job names for consistency
+      - sourceLabels: [job]
+        regex: "kubelet"
+        targetLabel: job
+        replacement: "kubernetes-metrics"
+
+      - sourceLabels: [job] 
+        regex: "kube-state-metrics"
+        targetLabel: job
+        replacement: "kubernetes-metrics"
+
+      - sourceLabels: [job]
+        regex: "monitoring/node-exporter-pods"
+        targetLabel: job
+        replacement: "node-exporter"
+
+---
+# ServiceAccount
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus-agent
+  namespace: monitoring
+
+---
+# ClusterRole - Enhanced permissions for better metric collection
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus-agent-scrape
+rules:
+  - apiGroups: [""]
+    resources: [nodes, nodes/proxy, services, endpoints, pods, namespaces, configmaps]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: [nodes/metrics, nodes/stats, nodes/log, nodes/spec, nodes/proxy/stats/summary]
+    verbs: ["get", "list", "watch"]
+  - nonResourceURLs:
+      - /metrics
+      - /metrics/cadvisor
+      - /metrics/resource
+      - /stats/summary
+    verbs: ["get"]
+  - apiGroups: ["extensions", "networking.k8s.io"]
+    resources: [ingresses]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["monitoring.coreos.com"]
+    resources: [servicemonitors, podmonitors, prometheusrules, probes]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: [deployments, replicasets, daemonsets, statefulsets]
+    verbs: ["get", "list", "watch"]
+
+---
+# ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-agent-scrape
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-agent-scrape
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-agent
+    namespace: monitoring
+
+---
+
+# ServiceMonitor for kubelet + cadvisor + resource - FIXED VERSION
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: kubelet-metrics
+  namespace: monitoring
+  labels:
+    release: prometheus-agent
+spec:
+  selector:
+    matchLabels:
+      k8s-app: kubelet
+  namespaceSelector:
+    matchNames: [kube-system]
+  endpoints:
+
+    # cAdvisor metrics - FIXED approach with proper label handling
+    - port: https-metrics
+      path: /metrics/cadvisor
+      scheme: https
+      interval: 15s
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig: { insecureSkipVerify: true }
+      metricRelabelings:
+      # Keep container metrics but be more selective
+      - sourceLabels: [__name__]
+        regex: 'container_(cpu|memory|network|fs)_.*'
+        action: keep
+        
+      # Keep only metrics that have container info (exclude pause containers and system containers)
+      - sourceLabels: [container]
+        regex: '^$|POD'
+        action: drop
+        
+      # Keep only metrics with actual pod names (not empty)
+      - sourceLabels: [pod]
+        regex: '^$'
+        action: drop
+        
+      # Ensure we have namespace information
+      - sourceLabels: [namespace]
+        regex: '^$'
+        action: drop
+
+      # The key fix: cAdvisor in recent Kubernetes versions provides these labels directly
+      # No need for complex relabeling from container_label_* as the labels should be present
+      
+      # Clean up any remaining container_label_* labels if they exist
+      - regex: 'container_label_.*'
+        action: labeldrop
+        
+      # Clean up other unnecessary labels
+      - regex: 'id|name|image_id'
+        action: labeldrop
+
+    # Kubelet metrics endpoint  
+    - port: https-metrics
+      path: /metrics
+      scheme: https
+      interval: 15s
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig: { insecureSkipVerify: true }
+      metricRelabelings:
+      # Keep only kubelet-specific metrics
+      - sourceLabels: [__name__]
+        regex: 'kubelet_.*|kubernetes_.*'
+        action: keep
+
+    # Resource metrics endpoint
+    - port: https-metrics  
+      path: /metrics/resource
+      scheme: https
+      interval: 15s
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig: { insecureSkipVerify: true }
+
+---
+# ServiceMonitor for kube-state-metrics
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: kube-state-metrics
+  namespace: monitoring
+  labels:
+    release: prometheus-agent
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kube-state-metrics
+  namespaceSelector:
+    matchNames: [kube-system]
+  endpoints:
+    - port: http
+      interval: 15s
+      path: /metrics
+
+---
+# PodMonitor for node-exporter
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: node-exporter-pods
+  namespace: monitoring
+  labels:
+    release: prometheus-agent
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-node-exporter
+  namespaceSelector:
+    matchNames: [monitoring]
+  podMetricsEndpoints:
+    - port: metrics
+      interval: 15s
+      path: /metrics
+
+---
+# ServiceMonitor for API server
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: apiserver
+  namespace: monitoring
+  labels:
+    release: prometheus-agent
+spec:
+  selector:
+    matchLabels:
+      component: apiserver
+  namespaceSelector:
+    matchNames: [default, kube-system]
+  endpoints:
+    - port: https
+      scheme: https
+      interval: 15s
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        insecureSkipVerify: false
+
+---
+# ServiceMonitor for Odigos services
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: odigos-system
+  namespace: monitoring
+  labels:
+    release: prometheus-agent
+spec:
+  selector:
+    matchLabels:
+      odigos.io/system-object: "true"
+  namespaceSelector:
+    matchNames:
+      - odigos-system
+  endpoints:
+    - port: metrics
+      interval: 15s
+      path: /metrics
+
+---
+# Improved PrometheusRule with better error handling
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: pod-enriched-metrics
+  namespace: monitoring
+spec:
+  groups:
+  - name: pod-enriched.rules
+    interval: 30s
+    rules:
+    # Basic container CPU usage rate
+    - record: container_cpu_usage_rate
+      expr: |
+        rate(container_cpu_usage_seconds_total{container!="",pod!="",namespace!=""}[5m])
+    
+    # CPU usage with pod info enrichment (if needed)
+    - record: container_cpu_usage_seconds_total:enriched
+      expr: |
+        sum by (namespace, pod, container, cluster, node) (
+          rate(container_cpu_usage_seconds_total{container!="",pod!="",namespace!="",image!=""}[5m])
+        )
+    
+    # CPU utilization percentage
+    - record: container_cpu_utilization
+      expr: |
+        (
+          rate(container_cpu_usage_seconds_total{container!="",pod!="",namespace!=""}[5m])
+          / 
+          on(namespace, pod, container) kube_pod_container_resource_limits{resource="cpu"}
+        ) * 100
+
+---
+# Additional ServiceMonitor to verify kubelet service discovery
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: kubelet-service-discovery
+  namespace: monitoring
+  labels:
+    release: prometheus-agent
+spec:
+  # This targets the kubelet service directly in kube-system
+  selector: {}
+  namespaceSelector:
+    matchNames: [kube-system]
+  endpoints:
+  - port: https-metrics
+    path: /metrics/cadvisor
+    scheme: https
+    interval: 15s
+    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    tlsConfig: 
+      insecureSkipVerify: true
+    # Alternative approach using kubernetes_sd_configs-like behavior
+    metricRelabelings:
+    - sourceLabels: [__name__]
+      regex: 'container_cpu_usage_seconds_total|container_memory_usage_bytes|container_network_.*'
+      action: keep
+    - sourceLabels: [container]
+      regex: '^$|POD'
+      action: drop
+    - sourceLabels: [pod]
+      regex: '^$'
+      action: drop


### PR DESCRIPTION
Refactor Prometheus ServiceMonitor relabeling rules and enhance RBAC for complete `container_cpu_usage_seconds_total` labels.

The previous Prometheus ServiceMonitor configuration for kubelet metrics used complex and outdated `metricRelabelings` to extract `pod`, `namespace`, and `container` labels. In modern Kubernetes/EKS, cAdvisor directly exposes these labels, making the old rules unnecessary and often causing labels to be dropped. This PR simplifies the relabeling to correctly capture these labels and adds filters to exclude incomplete metrics (e.g., pause containers or empty labels). RBAC permissions are also enhanced to ensure full access to required metric endpoints.

---
<a href="https://cursor.com/background-agent?bcId=bc-d3a8fc75-2da2-4af0-81d1-ca582d83ccec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d3a8fc75-2da2-4af0-81d1-ca582d83ccec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

