### PR TITLE
Configure eks cluster and prometheus monitoring

### DIFF
--- a/corrected-kubelet-servicemonitor.yaml
+++ b/corrected-kubelet-servicemonitor.yaml
@@ -1,0 +1,127 @@
+# ServiceMonitor for kubelet + cadvisor + resource - CORRECTED FOR EKS
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: kubelet-metrics
+  namespace: monitoring
+  labels:
+    release: prometheus-agent
+spec:
+  selector:
+    matchLabels:
+      k8s-app: kubelet
+  namespaceSelector:
+    matchNames: [kube-system]
+  endpoints:
+
+    # cAdvisor metrics - EKS compatible configuration
+    - port: https-metrics
+      path: /metrics/cadvisor
+      scheme: https
+      interval: 15s
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig: { insecureSkipVerify: true }
+      metricRelabelings:
+      # Keep container metrics that have actual container information
+      - sourceLabels: [__name__]
+        regex: 'container_.*'
+        action: keep
+        
+      # Drop system containers and pause containers that don't have useful pod info
+      - sourceLabels: [id]
+        regex: '/|/system.slice.*|/user.slice.*'
+        action: drop
+        
+      # Keep only containers that have pod information
+      - sourceLabels: [id]
+        regex: '/kubepods.slice/kubepods-[^/]+.slice/kubepods-[^/]+-pod[^/]+.slice/.*'
+        action: keep
+        
+      # Extract pod UID from the cgroup path for EKS
+      - sourceLabels: [id]
+        regex: '/kubepods.slice/kubepods-[^/]+.slice/kubepods-[^/]+-pod([^/]+).slice/.*'
+        targetLabel: pod_uid
+        replacement: '${1}'
+        action: replace
+        
+      # Replace underscores with dashes in pod_uid to match kube_pod_info
+      - sourceLabels: [pod_uid]
+        regex: '(.*)_(.*)_(.*)_(.*)_(.*)' 
+        targetLabel: pod_uid
+        replacement: '${1}-${2}-${3}-${4}-${5}'
+        action: replace
+
+    # Kubelet metrics endpoint  
+    - port: https-metrics
+      path: /metrics
+      scheme: https
+      interval: 15s
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig: { insecureSkipVerify: true }
+
+    # Resource metrics endpoint
+    - port: https-metrics  
+      path: /metrics/resource
+      scheme: https
+      interval: 15s
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig: { insecureSkipVerify: true }
+
+---
+# Updated PrometheusRule for proper pod enrichment
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: pod-enriched-metrics
+  namespace: monitoring
+spec:
+  groups:
+  - name: pod-enriched.rules
+    interval: 30s
+    rules:
+    # Enrich container metrics with pod information using pod_uid
+    - record: container_cpu_usage_seconds_total:enriched
+      expr: |
+        sum by (namespace, pod, container, cluster, node) (
+          rate(container_cpu_usage_seconds_total{container!="POD",container!="",image!=""}[5m])
+          * on (pod_uid) group_left(namespace, pod)
+            (kube_pod_info{} * on (uid) group_left() kube_pod_info{})
+        )
+        
+    - record: container_memory_usage_bytes:enriched  
+      expr: |
+        sum by (namespace, pod, container, cluster, node) (
+          container_memory_usage_bytes{container!="POD",container!="",image!=""}
+          * on (pod_uid) group_left(namespace, pod)
+            (kube_pod_info{} * on (uid) group_left() kube_pod_info{})
+        )
+
+---
+# Alternative approach: Use kube-state-metrics join
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule  
+metadata:
+  name: container-pod-join
+  namespace: monitoring
+spec:
+  groups:
+  - name: container-pod-join.rules
+    interval: 30s
+    rules:
+    # Create a mapping between container cgroup and pod info
+    - record: container_pod_mapping
+      expr: |
+        kube_pod_container_info 
+        * on (namespace, pod) group_left(uid, node, created_by_kind, created_by_name)
+          kube_pod_info
+          
+    # Join container metrics with pod information using container name and node
+    - record: container_cpu_usage_seconds_total:with_pod_info
+      expr: |
+        rate(container_cpu_usage_seconds_total{container!="POD",container!="",image!=""}[5m])
+        * on (container, node) group_left(namespace, pod, uid)
+          (
+            container_pod_mapping{container!=""}
+            * on (container, pod, namespace) group_left()
+              kube_pod_container_info
+          )

--- a/eks-optimized-monitoring.yaml
+++ b/eks-optimized-monitoring.yaml
@@ -1,0 +1,131 @@
+# EKS-Optimized ServiceMonitor for kubelet metrics
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: kubelet-metrics
+  namespace: monitoring
+  labels:
+    release: prometheus-agent
+spec:
+  selector:
+    matchLabels:
+      k8s-app: kubelet
+  namespaceSelector:
+    matchNames: [kube-system]
+  endpoints:
+
+    # cAdvisor metrics - Simplified approach for EKS
+    - port: https-metrics
+      path: /metrics/cadvisor
+      scheme: https
+      interval: 15s
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig: { insecureSkipVerify: true }
+      metricRelabelings:
+      # Keep all container metrics - let Prometheus rules handle the enrichment
+      - sourceLabels: [__name__]
+        regex: 'container_(cpu_usage_seconds_total|memory_usage_bytes|memory_working_set_bytes|fs_usage_bytes|network_.*)'
+        action: keep
+        
+      # Only keep metrics that have actual container names (not empty, not POD)
+      - sourceLabels: [container]
+        regex: '^$|POD'
+        action: drop
+
+    # Kubelet metrics endpoint  
+    - port: https-metrics
+      path: /metrics
+      scheme: https
+      interval: 15s
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig: { insecureSkipVerify: true }
+
+    # Resource metrics endpoint
+    - port: https-metrics  
+      path: /metrics/resource
+      scheme: https
+      interval: 15s
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig: { insecureSkipVerify: true }
+
+---
+# Enhanced PrometheusRule for EKS container metrics enrichment
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: eks-container-enrichment
+  namespace: monitoring
+spec:
+  groups:
+  - name: eks-container-enrichment.rules
+    interval: 15s
+    rules:
+    
+    # Create enriched CPU metrics with pod information
+    - record: container_cpu_usage_rate:enriched
+      expr: |
+        (
+          rate(container_cpu_usage_seconds_total{container!="",container!="POD",image!=""}[5m])
+          * on (pod, namespace) group_left(uid, node, created_by_kind, created_by_name, pod_ip)
+            kube_pod_info{}
+        )
+        
+    # Create enriched memory metrics  
+    - record: container_memory_usage_bytes:enriched
+      expr: |
+        (
+          container_memory_usage_bytes{container!="",container!="POD",image!=""}
+          * on (pod, namespace) group_left(uid, node, created_by_kind, created_by_name, pod_ip)
+            kube_pod_info{}
+        )
+        
+    # Working set memory (more accurate for limits)
+    - record: container_memory_working_set_bytes:enriched
+      expr: |
+        (
+          container_memory_working_set_bytes{container!="",container!="POD",image!=""}
+          * on (pod, namespace) group_left(uid, node, created_by_kind, created_by_name, pod_ip)
+            kube_pod_info{}
+        )
+
+    # Network metrics
+    - record: container_network_receive_bytes_total:enriched
+      expr: |
+        (
+          rate(container_network_receive_bytes_total{container!="",container!="POD"}[5m])
+          * on (pod, namespace) group_left(uid, node, created_by_kind, created_by_name, pod_ip)
+            kube_pod_info{}
+        )
+        
+    - record: container_network_transmit_bytes_total:enriched
+      expr: |
+        (
+          rate(container_network_transmit_bytes_total{container!="",container!="POD"}[5m])
+          * on (pod, namespace) group_left(uid, node, created_by_kind, created_by_name, pod_ip)
+            kube_pod_info{}
+        )
+
+---
+# Ensure kube-state-metrics is properly configured
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: kube-state-metrics-enhanced
+  namespace: monitoring
+  labels:
+    release: prometheus-agent
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kube-state-metrics
+  namespaceSelector:
+    matchNames: [kube-system]
+  endpoints:
+    - port: http
+      interval: 15s
+      path: /metrics
+      metricRelabelings:
+      # Ensure we keep pod info metrics
+      - sourceLabels: [__name__]
+        regex: 'kube_pod_info|kube_pod_container_info|kube_pod_status_.*'
+        action: keep


### PR DESCRIPTION
Update Prometheus Agent configuration to enrich EKS container metrics with pod and namespace labels.

EKS cAdvisor metrics often lack direct `pod` and `namespace` labels. This PR modifies the `ServiceMonitor` to collect raw container metrics and adds Prometheus recording rules to join these with `kube_pod_info`, ensuring proper label enrichment for container-level monitoring.

---
<a href="https://cursor.com/background-agent?bcId=bc-70f4d6bc-d3c0-47e7-b498-3ad24bd9bcf6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-70f4d6bc-d3c0-47e7-b498-3ad24bd9bcf6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

